### PR TITLE
Add configurable request timeout for provider calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.17] - 2026-04-28
+
+Configurable request timeout for provider calls ([PR #83][pr83]).
+
+### Added
+
+- **Request timeout**: Provider API calls now have a configurable timeout (default 60s) so a stuck upstream no longer hangs the CLI indefinitely. Configurable via `HOWTFDOI_REQUEST_TIMEOUT` env var or `request_timeout` config field (Go duration strings like `"30s"`, `"2m"`). Set to a negative value to disable the timeout for slow local models.
+- **Friendly timeout error**: On deadline expiry, the CLI shows a human-readable message with a hint to adjust `HOWTFDOI_REQUEST_TIMEOUT` instead of a raw `context.DeadlineExceeded`.
+- **Timeout test coverage**: New tests for `runQueryWithProvider` timeout behavior, negative-timeout bypass, and `resolveRequestTimeout` priority/parsing logic.
+
+### Changed
+
+- **`runQuery` refactored**: Provider creation and query execution split into `runQuery` / `runQueryWithProvider` so tests can inject mock providers without hitting a real API.
+
+[pr83]: https://github.com/NeckBeardPrince/howtfdoi/pull/83
+
 ## [1.0.16] - 2026-04-14
 
 Fixes from the v1.0.15 Copilot review ([PR #70][pr70]).
@@ -276,6 +292,7 @@ Fixes from the v1.0.15 Copilot review ([PR #70][pr70]).
 - Confirmation prompts before command execution
 - API key validation on startup
 
+[1.0.17]: https://github.com/NeckBeardPrince/howtfdoi/compare/v1.0.16...v1.0.17
 [1.0.16]: https://github.com/NeckBeardPrince/howtfdoi/compare/v1.0.15...v1.0.16
 [1.0.15]: https://github.com/NeckBeardPrince/howtfdoi/compare/v1.0.14...v1.0.15
 [1.0.14]: https://github.com/NeckBeardPrince/howtfdoi/compare/v1.0.10...v1.0.14

--- a/main.go
+++ b/main.go
@@ -65,6 +65,9 @@ const (
 	// Ollama defaults
 	defaultOllamaBaseURL = "http://localhost:11434/v1"
 	defaultOllamaModel   = "llama3.2"
+
+	// Default timeout for provider API calls (0 = use this default, <0 = no timeout)
+	defaultRequestTimeout = 60 * time.Second
 )
 
 var (
@@ -107,6 +110,7 @@ type FileConfig struct {
 	LMStudioModel   string `yaml:"lmstudio_model,omitempty"`
 	OllamaBaseURL   string `yaml:"ollama_base_url,omitempty"`
 	OllamaModel     string `yaml:"ollama_model,omitempty"`
+	RequestTimeout  string `yaml:"request_timeout,omitempty"` // Go duration string, e.g. "30s", "2m"
 }
 
 // Config holds runtime configuration
@@ -120,6 +124,7 @@ type Config struct {
 	LMStudioModel   string
 	OllamaBaseURL   string
 	OllamaModel     string
+	RequestTimeout  time.Duration // 0 = use defaultRequestTimeout, <0 = no timeout
 }
 
 // Response holds the parsed response.
@@ -413,12 +418,14 @@ func main() {
 		fmt.Fprintf(os.Stderr, "\nENVIRONMENT VARIABLES:\n")
 		fmt.Fprintf(os.Stderr, "  ANTHROPIC_API_KEY     Your Anthropic API key (get it at console.anthropic.com)\n")
 		fmt.Fprintf(os.Stderr, "  OPENAI_API_KEY        Your OpenAI API key (get it at platform.openai.com)\n")
-		fmt.Fprintf(os.Stderr, "  HOWTFDOI_AI_PROVIDER  Override provider choice: anthropic, openai, chatgpt, or lmstudio\n")
-		fmt.Fprintf(os.Stderr, "                        (defaults to anthropic, or auto-detects from available keys)\n")
-		fmt.Fprintf(os.Stderr, "  LMSTUDIO_BASE_URL     LM Studio server URL (default: %s)\n", defaultLMStudioBaseURL)
-		fmt.Fprintf(os.Stderr, "  LMSTUDIO_MODEL        LM Studio model name (default: %s)\n", defaultLMStudioModel)
-		fmt.Fprintf(os.Stderr, "  XDG_CONFIG_HOME       Override config directory (default: ~/.config)\n")
-		fmt.Fprintf(os.Stderr, "  XDG_STATE_HOME        Override state directory (default: ~/.local/state)\n")
+		fmt.Fprintf(os.Stderr, "  HOWTFDOI_AI_PROVIDER      Override provider choice: anthropic, openai, chatgpt, or lmstudio\n")
+		fmt.Fprintf(os.Stderr, "                            (defaults to anthropic, or auto-detects from available keys)\n")
+		fmt.Fprintf(os.Stderr, "  HOWTFDOI_REQUEST_TIMEOUT  Request timeout as a Go duration (e.g. 30s, 2m). Default: %v.\n", defaultRequestTimeout)
+		fmt.Fprintf(os.Stderr, "                            Set to a negative value (e.g. -1s) to disable the timeout.\n")
+		fmt.Fprintf(os.Stderr, "  LMSTUDIO_BASE_URL         LM Studio server URL (default: %s)\n", defaultLMStudioBaseURL)
+		fmt.Fprintf(os.Stderr, "  LMSTUDIO_MODEL            LM Studio model name (default: %s)\n", defaultLMStudioModel)
+		fmt.Fprintf(os.Stderr, "  XDG_CONFIG_HOME           Override config directory (default: ~/.config)\n")
+		fmt.Fprintf(os.Stderr, "  XDG_STATE_HOME            Override state directory (default: ~/.local/state)\n")
 
 		fmt.Fprintf(os.Stderr, "\nEXAMPLES:\n")
 		fmt.Fprintf(os.Stderr, "  howtfdoi list files\n")
@@ -525,6 +532,23 @@ func resolveOllamaConfig(fileConfig FileConfig) (baseURL, model string) {
 		model = defaultOllamaModel
 	}
 	return
+}
+
+// resolveRequestTimeout parses a request timeout from envVal (env var) or fileVal
+// (config file string). Returns defaultRequestTimeout when neither is set or valid.
+// A negative duration disables the timeout; zero means use the default.
+func resolveRequestTimeout(envVal, fileVal string) time.Duration {
+	if envVal != "" {
+		if d, err := time.ParseDuration(envVal); err == nil {
+			return d
+		}
+		color.Yellow("Warning: Invalid HOWTFDOI_REQUEST_TIMEOUT value %q, using default (%v)", envVal, defaultRequestTimeout)
+	} else if fileVal != "" {
+		if d, err := time.ParseDuration(fileVal); err == nil {
+			return d
+		}
+	}
+	return defaultRequestTimeout
 }
 
 func setupConfig(verbose bool) Config {
@@ -661,6 +685,7 @@ func setupConfig(verbose bool) Config {
 		LMStudioModel:   lmStudioModel,
 		OllamaBaseURL:   ollamaBaseURL,
 		OllamaModel:     ollamaModel,
+		RequestTimeout:  resolveRequestTimeout(os.Getenv("HOWTFDOI_REQUEST_TIMEOUT"), fileConfig.RequestTimeout),
 	}
 }
 
@@ -849,39 +874,55 @@ func runFirstTimeSetup() (FileConfig, error) {
 	return fc, nil
 }
 
-func runQuery(config Config, query string, showExamples bool) (*Response, error) {
-	// Create the appropriate provider
-	var provider Provider
-	switch config.Provider {
-	case providerOpenAI:
-		provider = NewOpenAIProvider(config.APIKey)
-	case providerAnthropic:
-		provider = NewAnthropicProvider(config.APIKey)
-	case providerLMStudio:
-		provider = NewLMStudioProvider(config.LMStudioBaseURL, config.LMStudioModel)
-	case providerOllama:
-		provider = NewOllamaProvider(config.OllamaBaseURL, config.OllamaModel)
-	default:
-		return nil, fmt.Errorf("unsupported provider: %s", config.Provider)
-	}
-
-	// Build system prompt with platform info
+// runQueryWithProvider sends the query to p using the timeout from config.
+// Extracted so tests can inject a mock provider without hitting a real API.
+func runQueryWithProvider(config Config, p Provider, query string, showExamples bool) (*Response, error) {
 	systemPrompt := buildSystemPrompt(config.Platform, showExamples)
 
-	// Build user query
 	userQuery := query
 	if !showExamples {
 		userQuery = fmt.Sprintf("Platform: %s\nQuery: %s", config.Platform, query)
 	}
 
-	// Query the provider
-	fullResponse, err := provider.Query(context.Background(), systemPrompt, userQuery)
+	ctx := context.Background()
+	cancel := context.CancelFunc(func() {})
+	var appliedTimeout time.Duration
+
+	if config.RequestTimeout >= 0 {
+		appliedTimeout = config.RequestTimeout
+		if appliedTimeout == 0 {
+			appliedTimeout = defaultRequestTimeout
+		}
+		ctx, cancel = context.WithTimeout(context.Background(), appliedTimeout)
+	}
+	defer func() { cancel() }()
+
+	fullResponse, err := p.Query(ctx, systemPrompt, userQuery)
 	if err != nil {
+		if appliedTimeout > 0 && errors.Is(err, context.DeadlineExceeded) {
+			return nil, fmt.Errorf("request timed out after %v. If you're on a slow local model, set HOWTFDOI_REQUEST_TIMEOUT to a larger value.", appliedTimeout)
+		}
 		return nil, err
 	}
 
-	// Parse the response
 	return parseResponse(fullResponse), nil
+}
+
+func runQuery(config Config, query string, showExamples bool) (*Response, error) {
+	var p Provider
+	switch config.Provider {
+	case providerOpenAI:
+		p = NewOpenAIProvider(config.APIKey)
+	case providerAnthropic:
+		p = NewAnthropicProvider(config.APIKey)
+	case providerLMStudio:
+		p = NewLMStudioProvider(config.LMStudioBaseURL, config.LMStudioModel)
+	case providerOllama:
+		p = NewOllamaProvider(config.OllamaBaseURL, config.OllamaModel)
+	default:
+		return nil, fmt.Errorf("unsupported provider: %s", config.Provider)
+	}
+	return runQueryWithProvider(config, p, query, showExamples)
 }
 
 func buildSystemPrompt(platform string, showExamples bool) string {

--- a/main_test.go
+++ b/main_test.go
@@ -488,6 +488,83 @@ func TestProviderRespectsContextCancellation(t *testing.T) {
 	}
 }
 
+// TestRunQueryTimeout verifies that runQueryWithProvider returns a friendly error
+// message when the provider call exceeds config.RequestTimeout.
+func TestRunQueryTimeout(t *testing.T) {
+	tempDir := t.TempDir()
+
+	config := Config{
+		RequestTimeout: 5 * time.Millisecond,
+		Platform:       "linux",
+		HistoryFile:    filepath.Join(tempDir, "history.log"),
+	}
+
+	_, err := runQueryWithProvider(config, &blockingMockProvider{}, "list files", false)
+	if err == nil {
+		t.Fatal("expected timeout error, got nil")
+	}
+	if !strings.Contains(err.Error(), "timed out") {
+		t.Errorf("expected friendly timeout message, got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "HOWTFDOI_REQUEST_TIMEOUT") {
+		t.Errorf("expected HOWTFDOI_REQUEST_TIMEOUT hint in error, got: %v", err)
+	}
+}
+
+// TestRunQueryNoTimeoutWhenNegative verifies that a negative RequestTimeout
+// disables the deadline, allowing the provider to run without a hard limit.
+func TestRunQueryNoTimeoutWhenNegative(t *testing.T) {
+	tempDir := t.TempDir()
+
+	// Use a provider that immediately returns (not blocking), just to confirm
+	// runQueryWithProvider succeeds when RequestTimeout < 0.
+	immediate := &immediateProvider{response: "echo hello\nPrints hello"}
+	config := Config{
+		RequestTimeout: -1,
+		Platform:       "linux",
+		HistoryFile:    filepath.Join(tempDir, "history.log"),
+	}
+
+	resp, err := runQueryWithProvider(config, immediate, "print hello", false)
+	if err != nil {
+		t.Fatalf("unexpected error with negative timeout: %v", err)
+	}
+	if resp.Command != "echo hello" {
+		t.Errorf("expected command 'echo hello', got %q", resp.Command)
+	}
+}
+
+// immediateProvider returns a fixed response without blocking.
+type immediateProvider struct{ response string }
+
+func (p *immediateProvider) Query(_ context.Context, _, _ string) (string, error) {
+	return p.response, nil
+}
+
+// TestResolveRequestTimeout verifies timeout resolution priority and parsing.
+func TestResolveRequestTimeout(t *testing.T) {
+	tests := []struct {
+		name    string
+		envVal  string
+		fileVal string
+		want    time.Duration
+	}{
+		{"env takes precedence", "30s", "2m", 30 * time.Second},
+		{"file used when env empty", "", "2m", 2 * time.Minute},
+		{"default when both empty", "", "", defaultRequestTimeout},
+		{"negative env (no timeout)", "-1s", "", -1 * time.Second},
+		{"invalid env falls back to default", "notaduration", "", defaultRequestTimeout},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := resolveRequestTimeout(tt.envVal, tt.fileVal)
+			if got != tt.want {
+				t.Errorf("resolveRequestTimeout(%q, %q) = %v, want %v", tt.envVal, tt.fileVal, got, tt.want)
+			}
+		})
+	}
+}
+
 // Benchmark stripMarkdown function
 func BenchmarkStripMarkdown(b *testing.B) {
 	input := "```bash\nls -la\n```\nThis is a command with **bold** and `code`"


### PR DESCRIPTION
Wraps provider calls in `context.WithTimeout` so a stuck upstream no longer hangs the CLI indefinitely. Default: 60s; configurable via `HOWTFDOI_REQUEST_TIMEOUT` env var or `request_timeout` config field. Negative value disables the timeout. Friendly error message on deadline expiry.

Closes #74

Generated with [Claude Code](https://claude.ai/code)